### PR TITLE
fix: disabling automount service account

### DIFF
--- a/charts/kube-workflow/templates/namespace.yaml
+++ b/charts/kube-workflow/templates/namespace.yaml
@@ -10,3 +10,4 @@ metadata:
   labels:
     application: {{ .Values.global.repositoryName }}
   name: {{ .Values.global.namespace }}
+automountServiceAccountToken: false


### PR DESCRIPTION
Security update disabeling autmount service token in default 
https://securecloud.blog/2021/08/17/azure-aks-reviewing-recommendations-from-security-center-disabling-automounting-api-credentials/