### PR TITLE
feat: add keycloak

### DIFF
--- a/packages/workflow/Chart.yaml
+++ b/packages/workflow/Chart.yaml
@@ -34,4 +34,7 @@ dependencies:
     repository: file://./charts/jobs
     condition: jobs.enabled
     version: 1.18.9
+  - name: keycloak
+    repository: https://codecentric.github.io/helm-charts
+    version: 18.0.1
 appVersion: 1.18.9


### PR DESCRIPTION
depends on kube-workflow external charts support