### PR TITLE
feat(oauth2): add additionnalArgs

### DIFF
--- a/packages/workflow/charts/oauth2-proxy/templates/deployment.yaml
+++ b/packages/workflow/charts/oauth2-proxy/templates/deployment.yaml
@@ -21,7 +21,12 @@ spec:
     spec:
       containers:
         - image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
-          args: ["--upstream",  {{ .Values.upstream }}]
+          args:
+            - --upstream
+            - {{ .Values.upstream }}
+            {{- if gt (len .Values.additionalArgs) 0 }}
+            {{- tpl (.Values.additionalArgs | toYaml) . | nindent 12 }}
+            {{- end }}
           name: app
           ports:
             - containerPort: 4180

--- a/packages/workflow/charts/oauth2-proxy/values.yaml
+++ b/packages/workflow/charts/oauth2-proxy/values.yaml
@@ -9,4 +9,5 @@ envFrom: []
 ingress:
   enabled: true
   annotations: {}
-upstream: 
+upstream:
+additionalArgs: []

--- a/packages/workflow/tests/__snapshots__/oauth2-proxy-args.prod.yaml
+++ b/packages/workflow/tests/__snapshots__/oauth2-proxy-args.prod.yaml
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`oauth2-proxy-args.prod 1`] = `
+"apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    field.cattle.io/projectId: '1234'
+    kubeworkflow/gitBranch: feature-branch-1
+    kubeworkflow/mainNamespace: 'true'
+    kapp.k14s.io/exists: ''
+  labels:
+    application: test-oauth2-proxy-args
+  name: test-oauth2-proxy-args
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: netpol-ingress
+  namespace: test-oauth2-proxy-args
+  annotations:
+    kapp.k14s.io/disable-original: ''
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: ingress-controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy/source: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: test-oauth2-proxy-args
+  annotations:
+    kapp.k14s.io/disable-original: ''
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: oauth2-proxy
+    application: test-oauth2-proxy-args
+  name: oauth2-proxy
+  namespace: test-oauth2-proxy-args
+  annotations:
+    kapp.k14s.io/disable-default-ownership-label-rules: ''
+    kapp.k14s.io/disable-default-label-scoping-rules: ''
+    kapp.k14s.io/disable-original: ''
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 4180
+  selector:
+    component: oauth2-proxy
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: oauth2-proxy
+    application: test-oauth2-proxy-args
+  name: oauth2-proxy
+  namespace: test-oauth2-proxy-args
+  annotations:
+    kapp.k14s.io/change-group: kube-workflow/test-oauth2-proxy-args
+    kapp.k14s.io/change-group.oauth2-proxy: kube-workflow/oauth2-proxy.test-oauth2-proxy-args
+    kapp.k14s.io/disable-original: ''
+    kapp.k14s.io/create-strategy: fallback-on-update
+    kapp.k14s.io/update-strategy: fallback-on-replace
+    kapp.k14s.io/nonce: ''
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        component: oauth2-proxy
+        application: test-oauth2-proxy-args
+    spec:
+      containers:
+        - image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
+          args:
+            - '--upstream'
+            - http://some.service:1234
+            - '--skip-auth-route'
+            - >-
+              ^/public/.*,^/app/dist/.*,^/api/public/.*,^/api/session/.*,^/app/assets/.*
+          name: app
+          ports:
+            - containerPort: 4180
+              name: http
+          resources:
+            limits:
+              cpu: 0.5
+              memory: 256Mi
+            requests:
+              cpu: 0.2
+              memory: 128Mi
+          livenessProbe:
+            failureThreshold: 15
+            httpGet:
+              path: /ping
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            failureThreshold: 15
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /ping
+              port: http
+            periodSeconds: 5
+            initialDelaySeconds: 30
+          env:
+            - name: OAUTH2_PROXY_HTTP_ADDRESS
+              value: 0.0.0.0:4180
+            - name: OAUTH2_PROXY_REDIRECT_URL
+              value: >-
+                https://test-oauth2-proxy-args.fabrique.social.gouv.fr/oauth2/callback
+            - name: SOME_ENV
+              value: some value
+          envFrom:
+            - secretRef:
+                name: some-secret
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io: cluster-issuer
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: 'true'
+    kapp.k14s.io/disable-original: ''
+  labels:
+    component: oauth2-proxy
+    application: test-oauth2-proxy-args
+  name: oauth2-proxy
+  namespace: test-oauth2-proxy-args
+spec:
+  rules:
+    - host: oauth2-proxy-test-oauth2-proxy-args.fabrique.social.gouv.fr
+      http:
+        paths:
+          - backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - oauth2-proxy-test-oauth2-proxy-args.fabrique.social.gouv.fr
+      secretName: oauth2-proxy-crt
+"
+`;

--- a/packages/workflow/tests/samples/oauth2-proxy-args/values.yaml
+++ b/packages/workflow/tests/samples/oauth2-proxy-args/values.yaml
@@ -1,0 +1,12 @@
+oauth2-proxy:
+  enabled: true
+  upstream: http://some.service:1234
+  envFrom:
+    - secretRef:
+        name: "some-secret"
+  env:
+    - name: SOME_ENV
+      value: "some value"
+  additionalArgs:
+    - --skip-auth-route
+    - ^/public/.*,^/app/dist/.*,^/api/public/.*,^/api/session/.*,^/app/assets/.*


### PR DESCRIPTION
Allow to add args to the oauth2-proxy setup. handy for example to whitelist some routes